### PR TITLE
Add pointer hooks 

### DIFF
--- a/hooks/useBounds.tsx
+++ b/hooks/useBounds.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react";
 
-type BoundingBoxInfo = {
+export type BoundingBoxInfo = {
   x: number;
   y: number;
   width: number;
@@ -33,7 +33,7 @@ type BoundingBoxInfo = {
  * @returns [containerRef, bounds]
  */
 export function useBounds<T extends HTMLElement>(
-  dependency?: any[],
+  dependency: any[] = [],
 ): [MutableRefObject<T>, BoundingBoxInfo] {
   const containerRef = useRef<T>() as MutableRefObject<T>;
   const [bounds, setBounds] = useState({
@@ -72,4 +72,46 @@ export function useBounds<T extends HTMLElement>(
   }, dependency);
 
   return [containerRef, bounds];
+}
+
+export function useBoundsWithRef<T extends HTMLElement>(
+  containerRef: MutableRefObject<T>,
+  dependency: any[] = [],
+): BoundingBoxInfo {
+  const [bounds, setBounds] = useState({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+  });
+
+  useLayoutEffect(() => {
+    const handleResize = () => {
+      const bounds = containerRef.current.getBoundingClientRect();
+
+      const scrollOffset = window.scrollY;
+
+      setBounds({
+        x: bounds.x,
+        y: bounds.y + scrollOffset,
+        width: bounds.width,
+        height: bounds.height,
+        left: bounds.left,
+        right: bounds.right,
+        top: bounds.top + scrollOffset,
+        bottom: bounds.bottom + scrollOffset,
+      });
+    };
+    window.addEventListener("resize", handleResize);
+    handleResize();
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, dependency);
+
+  return bounds;
 }

--- a/hooks/useBounds.tsx
+++ b/hooks/useBounds.tsx
@@ -74,7 +74,7 @@ export function useBounds<T extends HTMLElement>(
   return [containerRef, bounds];
 }
 
-export function useBoundsWithRef<T extends HTMLElement>(
+export function useContainerBounds<T extends HTMLElement>(
   containerRef: MutableRefObject<T>,
   dependency: any[] = [],
 ): BoundingBoxInfo {

--- a/hooks/useBounds.tsx
+++ b/hooks/useBounds.tsx
@@ -74,6 +74,12 @@ export function useBounds<T extends HTMLElement>(
   return [containerRef, bounds];
 }
 
+/**
+ * just like useBounds, but it allows you to feed in the container ref instead.
+ * @param containerRef
+ * @param dependency
+ * @returns
+ */
 export function useContainerBounds<T extends HTMLElement>(
   containerRef: MutableRefObject<T>,
   dependency: any[] = [],

--- a/hooks/usePointerInfo.ts
+++ b/hooks/usePointerInfo.ts
@@ -1,0 +1,39 @@
+import { useMotionValue, useTransform } from "framer-motion";
+import { useEffect } from "react";
+import { BoundingBoxInfo } from "./useBounds";
+
+export function usePointerOffset(
+  shouldTrack: boolean,
+  boundingBox: BoundingBoxInfo,
+) {
+  const pointer = usePointerPosition(shouldTrack);
+
+  const x = useTransform(pointer.x, (latest) => {
+    return latest - boundingBox.left;
+  });
+  const y = useTransform(pointer.y, (latest) => {
+    return latest - boundingBox.top;
+  });
+
+  return { x, y };
+}
+
+export function usePointerPosition(shouldTrack: boolean) {
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+
+  useEffect(() => {
+    const handlePointerMove = (e: PointerEvent) => {
+      x.set(e.clientX);
+      y.set(e.clientY);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+    };
+  }, [x, y, shouldTrack]);
+
+  return { x, y };
+}

--- a/hooks/usePointerInfo.ts
+++ b/hooks/usePointerInfo.ts
@@ -2,6 +2,13 @@ import { useMotionValue, useTransform } from "framer-motion";
 import { useEffect } from "react";
 import { BoundingBoxInfo } from "./useBounds";
 
+/**
+ * Returns MotionValues that tracks the clientX, and clientY of the mouse position.
+ *
+ * @param shouldTrack
+ * @param boundingBox
+ * @returns
+ */
 export function usePointerOffset(
   shouldTrack: boolean,
   boundingBox: BoundingBoxInfo,
@@ -18,6 +25,12 @@ export function usePointerOffset(
   return { x, y };
 }
 
+/**
+ * Just like usePointerPosition, but you feed in the pointer bounding box.
+ * @param containerRef
+ * @param dependency
+ * @returns
+ */
 export function usePointerPosition(shouldTrack: boolean) {
   const x = useMotionValue(0);
   const y = useMotionValue(0);


### PR DESCRIPTION
Useful hooks for building pointer interactions.

## usePointerPosition(shouldTrack:boolean)

Returns MotionValues that tracks the clientX, and clientY of the mouse position.

```
const pointer = usePointerPosition(true); // the shouldTrack boolean parameters dictates will the pointerMove listener be active 
pointer.x // MotionValue of pointer X
pointer.y // MotionValue of pointer Y

// example: 
// the more the user move to the right, the more opacity it will have until 200
const opacity = useTransform(pointer.x, [0,200], [0,1]);
```

## usePointerOffset(shouldTrack: boolean, boundingBox: BoundingBoxInfo)

Just like usePointerPosition, but you feed in the pointer bounding box.

```
const containerRef = useRef() as MutableRefObject<HTMLDivElement>;
const bounds = useContainerBounds(containerRef);
const pointer = usePointerOffset(bounds, true); 
// this will be relative to the mouse offset to the container element, instead of the position
const opacity = useTransform(pointer.x, [0,200], [0,1]);
```

## Extra notes on useBounds vs useContainerBounds

useContainerBounds is just like useBounds, but it allows you to feed in the container ref instead. In the future, we may consider migrating all the code to this implementation as this is more versatile.
